### PR TITLE
Fix: correctly detect android platform.

### DIFF
--- a/src/lib/capabilities.js
+++ b/src/lib/capabilities.js
@@ -33,7 +33,7 @@ goog.scope(function() {
   capabilities.platform_ =
     // Android 1.6 doesn't have a value for navigator.platform
     window.navigator.platform ?
-    window.navigator.platform.toLowerCase() :
+    (/Linux armv[6,7]l/.test(window.navigator.platform) ? 'android' : window.navigator.platform.toLowerCase()) :
     /android/.test(capabilities.ua_) ? 'android' : 'unknown';
 
   /**


### PR DESCRIPTION
Many devices set navigator.platform to "Linux armv7l", so that they
end up having class os-linux instead of os-android.
