### PR TITLE
Add ID strings to debugging messages referring to DOM nodes

### DIFF
--- a/src/layout/block.js
+++ b/src/layout/block.js
@@ -62,7 +62,7 @@ goog.scope(function() {
       // This is a very defensive move, since a display: none item that
       // is made visible when in a specific column or grid can really mess up a
       // layout
-      debug.warn('Zero-height block ignored');
+      debug.warn('Zero-height block ignored: ' + debug.idnode(node));
 
       this.ignore = true;
       return;
@@ -588,7 +588,7 @@ goog.scope(function() {
   Block.sanitizeNode = function(node, baseLineHeight) {
     // Should never get text & comment nodes
     if (node.nodeType !== 1) {
-      debug.error('Text node sent to sanitize: ' + node);
+      debug.error('Text node sent to sanitize: ' + debug.idnode(node));
       return node;
     }
 
@@ -702,7 +702,7 @@ goog.scope(function() {
     if (metrics.outerH % baseLineHeight) {
       // Shit, looks like even with the normalization, we're still out of
       // sync. Use padding bottom to fix it up
-      debug.info('Forcing padding due to mismatch: ' + node);
+      debug.info('Forcing padding due to mismatch: ' + debug.idnode(node));
 
       metrics.paddingBottom += baseLineHeight - metrics.outerH % baseLineHeight;
 

--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -95,6 +95,30 @@ goog.scope(function() {
   };
 
   /**
+   * Helper that returns an identifying string for an HTML element
+   * @param {element} node 
+   */
+  debug.idnode = function (node) {
+    // ID is most accurate
+    var identifier = node.getAttribute('id');
+    if(goog.isString(id)) {  
+        return '#'+id;
+    }
+    // data-sizes is usually rather specific
+    identifier = node.getAttribute('data-sizes');
+    if(goog.isString(identifier)) {  
+        return node+' (data-sizes='+identifier+')';
+    }
+    // classes identify it better than nothing
+    identifier = node.getAttribute('class');
+    if(goog.isString(identifier)) {  
+        return node+' (class='+identifier+')';
+    }
+    // Can't identify it, just return
+    return node;
+  };
+
+  /**
    * Assert helper
    * @param {boolean} assertion
    * @param {?string} msg


### PR DESCRIPTION
Added a method to the debug object that generates an identifying string (based on id, data-sizes or class) for a DOM node.
Helps identify which nodes are bing referred to, i.e. in "Zero-height block ignored" messages, so that it's easier to figure out what the problem might be.

"Zero-height block ignored" becomes "Zero-height block ignored: [object HTMLDivElement](data-sizes =smallarticle fallback)", which provides a lot more to go on.
